### PR TITLE
fix: Render popups within style scope div

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,5 +1,5 @@
 import { ConfigProvider as AntdConfigProvider } from 'antd';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useRef } from 'react';
 import { ThemeProvider } from 'styled-components';
 
 import { MLL_THEME, MllTheme } from './theme';
@@ -12,14 +12,22 @@ export function Provider({
   children,
   theme,
 }: PropsWithChildren<ProviderProps>) {
+  const styleScopeDiv = useRef(null);
+
   AntdConfigProvider.config({
     prefixCls: PREFIX_CLS,
   });
 
   return (
     <ThemeProvider theme={{ ...MLL_THEME, ...theme }}>
-      <AntdConfigProvider prefixCls={PREFIX_CLS}>
-        <div id={PREFIX_CLS}>{children}</div>
+      <AntdConfigProvider
+        prefixCls={PREFIX_CLS}
+        // Necessary so that styles apply to components such as Tooltip
+        getPopupContainer={() => styleScopeDiv.current ?? document.body}
+      >
+        <div id={PREFIX_CLS} ref={styleScopeDiv}>
+          {children}
+        </div>
       </AntdConfigProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
This ensures that styles apply to components such as Tooltip.