### PR TITLE
fix: default Table.rowKey to "id"

### DIFF
--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -1,12 +1,12 @@
 import { Table as AntdTable, TableProps as AntdTableProps } from 'antd';
-import { ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 
 export { ColumnsType, ColumnProps } from 'antd/es/table';
 
 export type TableProps<RecordType> = AntdTableProps<RecordType>;
 
-export const Table = styled(AntdTable)`
+export const StyledTable = styled(AntdTable)`
   ${(props) => {
     if (props.onRow?.({})?.onClick) {
       return `
@@ -21,3 +21,9 @@ export const Table = styled(AntdTable)`
 ` as <RecordType extends Record<string, unknown> = Record<string, unknown>>(
   props: TableProps<RecordType>,
 ) => ReactElement;
+
+export function Table<
+  RecordType extends Record<string, unknown> = Record<string, unknown>,
+>(props: TableProps<RecordType>) {
+  return <StyledTable rowKey="id" {...props} />;
+}


### PR DESCRIPTION
This solves the most common use case we have, which is rendering
data from a GraphQL endpoint. By convention, we always use "id"
as the identifying field.