### PR TITLE
feat: highlight button on focus like on hover

### DIFF
--- a/src/Button/ColoredButtons.tsx
+++ b/src/Button/ColoredButtons.tsx
@@ -27,7 +27,8 @@ export const FilledButton = styled(AntdButton as ColoredButtonType)`
   border-color: ${colorFromPropsOrTheme} !important;
   color: white !important;
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: transparent !important;
     color: ${colorFromPropsOrTheme} !important;
   }
@@ -38,7 +39,8 @@ export const GhostButton = styled(AntdButton as ColoredButtonType)`
   border-color: ${colorFromPropsOrTheme} !important;
   color: ${colorFromPropsOrTheme} !important;
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: ${colorFromPropsOrTheme} !important;
     color: white !important;
   }


### PR DESCRIPTION
This aligns with the default behavior of antd: hover and focus visualization are the same.