### PR TITLE
Disabled button style

### DIFF
--- a/src/Button/ColoredButtons.tsx
+++ b/src/Button/ColoredButtons.tsx
@@ -36,7 +36,7 @@ export const FilledButton = styled(AntdButton as ColoredButtonType)`
   }
 
   &[disabled] {
-    color: ${(props) => props.theme.disabledColors.lowContrast};
+    color: ${(props) => props.theme.disabledColors?.lowContrast};
   }
 `;
 
@@ -54,6 +54,6 @@ export const GhostButton = styled(AntdButton as ColoredButtonType)`
   }
 
   &[disabled] {
-    color: ${(props) => props.theme.disabledColors.lowContrast};
+    color: ${(props) => props.theme.disabledColors?.lowContrast};
   }
 `;

--- a/src/Button/ColoredButtons.tsx
+++ b/src/Button/ColoredButtons.tsx
@@ -23,25 +23,25 @@ function colorFromPropsOrTheme(
 }
 
 export const FilledButton = styled(AntdButton as ColoredButtonType)`
-  background: ${colorFromPropsOrTheme} !important;
-  border-color: ${colorFromPropsOrTheme} !important;
-  color: white !important;
+  background: ${colorFromPropsOrTheme};
+  border-color: ${colorFromPropsOrTheme};
+  color: white;
 
   &:hover,
   &:focus {
-    background: transparent !important;
-    color: ${colorFromPropsOrTheme} !important;
+    background: transparent;
+    color: ${colorFromPropsOrTheme};
   }
 `;
 
 export const GhostButton = styled(AntdButton as ColoredButtonType)`
-  background: transparent !important;
-  border-color: ${colorFromPropsOrTheme} !important;
-  color: ${colorFromPropsOrTheme} !important;
+  background: transparent;
+  border-color: ${colorFromPropsOrTheme};
+  color: ${colorFromPropsOrTheme};
 
   &:hover,
   &:focus {
-    background: ${colorFromPropsOrTheme} !important;
-    color: white !important;
+    background: ${colorFromPropsOrTheme};
+    color: white;
   }
 `;

--- a/src/Button/ColoredButtons.tsx
+++ b/src/Button/ColoredButtons.tsx
@@ -33,6 +33,10 @@ export const FilledButton = styled(AntdButton as ColoredButtonType)`
     border-color: ${colorFromPropsOrTheme};
     color: ${colorFromPropsOrTheme};
   }
+
+  &[disabled] {
+    color: ${(props) => props.theme.disabledColors.lowContrast};
+  }
 `;
 
 export const GhostButton = styled(AntdButton as ColoredButtonType)`
@@ -45,5 +49,9 @@ export const GhostButton = styled(AntdButton as ColoredButtonType)`
     background: ${colorFromPropsOrTheme};
     border-color: ${colorFromPropsOrTheme};
     color: ${PALETTE.white};
+  }
+
+  &[disabled] {
+    color: ${(props) => props.theme.disabledColors.lowContrast};
   }
 `;

--- a/src/Button/ColoredButtons.tsx
+++ b/src/Button/ColoredButtons.tsx
@@ -3,7 +3,7 @@ import ButtonGroup from 'antd/es/button/button-group';
 import * as React from 'react';
 import styled, { ThemedStyledProps } from 'styled-components';
 
-import { Theme } from '../theme';
+import { PALETTE, Theme } from '../theme';
 
 export type ColoredButtonType = {
   Group: typeof ButtonGroup;
@@ -25,11 +25,12 @@ function colorFromPropsOrTheme(
 export const FilledButton = styled(AntdButton as ColoredButtonType)`
   background: ${colorFromPropsOrTheme};
   border-color: ${colorFromPropsOrTheme};
-  color: white;
+  color: ${PALETTE.white};
 
   &:hover,
   &:focus {
     background: transparent;
+    border-color: ${colorFromPropsOrTheme};
     color: ${colorFromPropsOrTheme};
   }
 `;
@@ -42,6 +43,7 @@ export const GhostButton = styled(AntdButton as ColoredButtonType)`
   &:hover,
   &:focus {
     background: ${colorFromPropsOrTheme};
-    color: white;
+    border-color: ${colorFromPropsOrTheme};
+    color: ${PALETTE.white};
   }
 `;

--- a/src/Button/index.stories.tsx
+++ b/src/Button/index.stories.tsx
@@ -55,7 +55,9 @@ export const SaveWithHotkey: Story<SaveButtonByNumpadEnterProps> = (args) => (
     <SaveButtonByNumpadEnter {...args} />
   </div>
 );
-export const Info: Story<ButtonProps> = (args) => <InfoButton {...args} />;
+export const Info: Story<ButtonProps> = (args) => (
+  <InfoButton {...args}>Info</InfoButton>
+);
 export const Edit: Story<ButtonProps> = (args) => <EditButton {...args} />;
 export const Warning: Story<ButtonProps> = (args) => (
   <WarningButton {...args}>Do something slightly dangerous</WarningButton>

--- a/src/Button/index.stories.tsx
+++ b/src/Button/index.stories.tsx
@@ -34,6 +34,11 @@ export default {
         type: 'boolean',
       },
     },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 };
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -46,6 +46,9 @@ export const THEME = {
   panelBackgroundColor: DEPRECATED_PALETTE.gray1,
   tableBorderColor: PALETTE.gray3,
   titleColor: PALETTE.gray5,
+  disabledColors: {
+    lowContrast: PALETTE.gray5,
+  },
 
   // UI states
   successColor: PALETTE.green,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -51,7 +51,7 @@ export const THEME = {
   successColor: PALETTE.green,
   warningColor: PALETTE.gold,
   errorColor: PALETTE.red,
-  infoColor: PALETTE.gray4,
+  infoColor: PALETTE.gray7,
 };
 
 export type Theme = typeof THEME;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -46,6 +46,9 @@ export type Theme = {
   panelBackgroundColor: string;
   tableBorderColor: string;
   titleColor: string;
+  disabledColors?: {
+    lowContrast: string;
+  };
 
   successColor: string;
   warningColor: string;


### PR DESCRIPTION
Resolves: https://github.com/mll-lab/react-components/issues/106

Example screenshots of resulting styles:

`<Button>`

![image](https://user-images.githubusercontent.com/4804412/145813359-9ee6698e-4542-4974-87dd-32935fbef530.png)

`<Button disabled>`

![image](https://user-images.githubusercontent.com/4804412/145814209-058fbc23-892d-44a5-a501-cb42045eafed.png)

`<InfoButton>`

![image](https://user-images.githubusercontent.com/4804412/145814156-2e89f99b-9380-42ca-be7f-a9ea333bf959.png)

`<InfoButton disabled>`

![image](https://user-images.githubusercontent.com/4804412/145814275-7ae4e6b8-ec61-4c4c-adc4-a65c28a242f5.png)

Also fixes the `InfoButton`, which was not visible in the stories before and which had a very low contrast (on a bright background). @spawnia @SimBig is this change ok, or was the very light gray necessary?
