### PR TITLE
feat: export InputRef type

### DIFF
--- a/src/Input/common.ts
+++ b/src/Input/common.ts
@@ -3,12 +3,14 @@ import {
   InputNumber as AntdInputNumber,
   InputNumberProps as AntdInputNumberProps,
   InputProps as AntdInputProps,
+  InputRef as AntdInputRef,
 } from 'antd';
 import styled from 'styled-components';
 
 import { fontSizeFromTheme } from '../styled-utils';
 
 export type InputProps = AntdInputProps;
+export type InputRef = AntdInputRef;
 export type InputNumberProps = AntdInputNumberProps;
 
 export const Input: typeof AntdInput = styled(AntdInput)`


### PR DESCRIPTION
So it is possible to properly type refs outside of the library.