### PR TITLE
fix: adapt steps to font size and center icon vertically

### DIFF
--- a/src/Provider/index.stories.tsx
+++ b/src/Provider/index.stories.tsx
@@ -38,6 +38,7 @@ import {
   CustomDropdown as SelectCustomDropdownStory,
 } from '../Select/index.stories';
 import { Space } from '../Space';
+import { Simple as SimpleStepsStory } from '../Steps/index.stories';
 import { Table } from '../Table';
 import { Tag } from '../Tag';
 import { Typography } from '../Typography';
@@ -199,6 +200,7 @@ function SupportedComponents() {
       <TabsCardStory />
       <CardsGridStory />
       <CardMetaStory />
+      <SimpleStepsStory />
     </Space>
   );
 }

--- a/src/Steps/index.tsx
+++ b/src/Steps/index.tsx
@@ -3,7 +3,17 @@ import {
   StepsProps as AntdStepsProps,
   StepProps as AntdStepProps,
 } from 'antd';
+import styled from 'styled-components';
 
-export const Steps: typeof AntdSteps = AntdSteps;
+import { fontSizeFromTheme } from '../styled-utils';
+
 export type StepsProps = AntdStepsProps;
 export type StepProps = AntdStepProps;
+
+export const Steps: typeof AntdSteps = styled(AntdSteps)`
+  font-size: ${fontSizeFromTheme};
+
+  .mll-ant-steps-icon {
+    top: -5%;
+  }
+`;


### PR DESCRIPTION
Previous (without vertical alignment):

![image](https://user-images.githubusercontent.com/4804412/189686352-2715e23a-4c03-48c0-878f-da2353bbc6aa.png)


After (with vertical alignment):

![image](https://user-images.githubusercontent.com/4804412/189686389-9745c183-8891-4bea-aa30-a20bc75da94d.png)
