### PR TITLE
fix: button gaps for Modal.confirm

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { Modal as AntdModal, ModalProps as AntdModalProps } from 'antd';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 
 export type ModalProps = AntdModalProps;
 export const Modal: typeof AntdModal = styled(AntdModal)`
@@ -8,6 +8,15 @@ export const Modal: typeof AntdModal = styled(AntdModal)`
   .mll-ant-modal-footer
     .mll-ant-btn
     + .mll-ant-btn:not(.mll-ant-dropdown-trigger) {
+    margin-bottom: 0;
+    margin-left: 8px;
+  }
+`;
+
+export const ModalConfirmStyles = createGlobalStyle`
+  // Fixes antd bug where prefixes do not apply correctly on all classes.
+  // Styles are copied from antd.
+  .mll-ant-modal-confirm .mll-ant-modal-confirm-btns .mll-ant-btn + .mll-ant-btn {
     margin-bottom: 0;
     margin-left: 8px;
   }

--- a/src/Modal/index.stories.tsx
+++ b/src/Modal/index.stories.tsx
@@ -50,16 +50,14 @@ export const OpenFullScreenByButton: Story<ModalProps> =
     );
   };
 
-export const ModalConfirm: Story<ModalProps> =
-  function ModalConfirm(args) {
-    const openModal = () => Modal.confirm({
-      title: "Programmatically opened confirm modal",
-      content: "Some content",
+export const ModalConfirm: Story<ModalProps> = function ModalConfirm(args) {
+  const openModal = () =>
+    Modal.confirm({
+      title: 'Programmatically opened confirm modal',
+      content: 'Some content',
       okText: 'Yes',
       cancelText: 'No',
       width: args.width,
-    })
-    return (
-      <Button onClick={openModal}>Open Modal</Button>
-    );
-  };
+    });
+  return <Button onClick={openModal}>Open Modal</Button>;
+};

--- a/src/Modal/index.stories.tsx
+++ b/src/Modal/index.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Button } from '../Button/Button';
 
 import { FullScreenModal } from './FullScreenModal';
-import { ModalProps } from './Modal';
+import { Modal, ModalProps } from './Modal';
 import { WithModal, WithModalProps } from './WithModal';
 
 export default {
@@ -47,5 +47,19 @@ export const OpenFullScreenByButton: Story<ModalProps> =
         <p>Some contents...</p>
         <p>Some contents...</p>
       </WithModal>
+    );
+  };
+
+export const ModalConfirm: Story<ModalProps> =
+  function ModalConfirm(args) {
+    const openModal = () => Modal.confirm({
+      title: "Programmatically opened confirm modal",
+      content: "Some content",
+      okText: 'Yes',
+      cancelText: 'No',
+      width: args.width,
+    })
+    return (
+      <Button onClick={openModal}>Open Modal</Button>
     );
   };

--- a/src/Provider/index.tsx
+++ b/src/Provider/index.tsx
@@ -1,10 +1,10 @@
-import { ConfigProvider as AntdConfigProvider } from "antd";
+import { ConfigProvider as AntdConfigProvider } from 'antd';
 import deDE from 'antd/lib/locale/de_DE';
 import React, { PropsWithChildren } from 'react';
-import { ThemeProvider } from "styled-components";
+import { ThemeProvider } from 'styled-components';
 
+import { ModalConfirmStyles } from '../Modal';
 import { THEME, Theme } from '../theme';
-import { ModalConfirmStyles } from "../Modal";
 
 type ProviderProps = { theme?: Partial<Theme> };
 

--- a/src/Provider/index.tsx
+++ b/src/Provider/index.tsx
@@ -1,9 +1,10 @@
-import { ConfigProvider as AntdConfigProvider } from 'antd';
+import { ConfigProvider as AntdConfigProvider } from "antd";
 import deDE from 'antd/lib/locale/de_DE';
 import React, { PropsWithChildren } from 'react';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider } from "styled-components";
 
 import { THEME, Theme } from '../theme';
+import { ModalConfirmStyles } from "../Modal";
 
 type ProviderProps = { theme?: Partial<Theme> };
 
@@ -24,6 +25,7 @@ export function Provider({
         prefixCls={PREFIX_CLS}
         componentSize={theme?.size}
       >
+        <ModalConfirmStyles />
         {children}
       </AntdConfigProvider>
     </ThemeProvider>


### PR DESCRIPTION
As the Modal.confirm dialog is rendered outside the provider div, a global style is required.