### PR TITLE
feat: make card border visible on default background color

### DIFF
--- a/src/Card/index.stories.tsx
+++ b/src/Card/index.stories.tsx
@@ -1,6 +1,8 @@
 import { Story } from '@storybook/react';
 import React from 'react';
 
+import { THEME } from '../theme';
+
 import { Card, CardProps } from './index';
 
 export default {
@@ -68,3 +70,18 @@ export const CardMeta: Story<CardProps> = function CardMeta(args) {
     </Card>
   );
 };
+
+export const CardOnColoredBackground: Story<CardProps> =
+  function CardOnColoredBackground(args) {
+    return (
+      <div style={{ background: THEME.backgroundColor, padding: 20 }}>
+        <Card
+          style={{ width: 240 }}
+          title="Card on background with default color"
+          {...args}
+        >
+          <p>Border is visible even when there is a background color</p>
+        </Card>
+      </div>
+    );
+  };

--- a/src/Card/index.tsx
+++ b/src/Card/index.tsx
@@ -14,6 +14,9 @@ const StyledCard = styled(AntdCard)`
   .mll-ant-card-extra {
     font-size: ${fontSizeFromTheme};
   }
+  &.mll-ant-card-bordered {
+    border: 1px solid ${(props) => props.theme.containerBorderColor};
+  }
 `;
 
 export const Card: typeof AntdCard = StyledCard;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4804412/210785868-e2140d2f-92ef-485e-9ba5-f4df15c17404.png)


Now:

![image](https://user-images.githubusercontent.com/4804412/210785781-d07d0bdf-932a-421f-b4ef-ce8e692fde65.png)

This improves the visuals a bit when cards are used on the default background color. It's not that an obvious improvement in these screenshots, but when used in the context of our applications there is an improvement visible.
