### PR TITLE
fix: jump of user popover

### DIFF
--- a/src/UserDetailsPopover/index.stories.tsx
+++ b/src/UserDetailsPopover/index.stories.tsx
@@ -81,9 +81,7 @@ export const WithCustomChildren: Story = function Link(args) {
         marginLeft: 100,
       }}
     >
-      <UserDetailsPopover loading={args.loading} user={userProps}>
-        {args.username}
-      </UserDetailsPopover>
+      <UserDetailsPopover user={userProps}>{args.username}</UserDetailsPopover>
     </Space>
   );
 };

--- a/src/UserDetailsPopover/index.stories.tsx
+++ b/src/UserDetailsPopover/index.stories.tsx
@@ -20,6 +20,12 @@ export default {
       },
       defaultValue: false,
     },
+    userUndefined: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+    },
   },
 };
 
@@ -40,14 +46,18 @@ export const Default: Story = function Link(args) {
       <UserAvatarWithDetailsPopover
         acronym={args.acronym}
         onOpen={handleOnOpen}
-        user={{
-          acronym: args.acronym,
-          email: args.email,
-          firstname: args.firstname,
-          lastname: args.lastname,
-          username: args.username,
-          inactive: args.inactive,
-        }}
+        user={
+          args.userUndefined
+            ? undefined
+            : {
+                acronym: args.acronym,
+                email: args.email,
+                firstname: args.firstname,
+                lastname: args.lastname,
+                username: args.username,
+                inactive: args.inactive,
+              }
+        }
       />
     </Space>
   );
@@ -74,7 +84,9 @@ export const WithCustomChildren: Story = function Link(args) {
         marginLeft: 100,
       }}
     >
-      <UserDetailsPopover user={userProps}>{args.username}</UserDetailsPopover>
+      <UserDetailsPopover user={args.userUndefined ? undefined : userProps}>
+        {args.username}
+      </UserDetailsPopover>
     </Space>
   );
 };

--- a/src/UserDetailsPopover/index.stories.tsx
+++ b/src/UserDetailsPopover/index.stories.tsx
@@ -14,12 +14,6 @@ export default {
     firstname: { control: { type: 'text' }, defaultValue: 'John' },
     lastname: { control: { type: 'text' }, defaultValue: 'Doe' },
     username: { control: { type: 'text' }, defaultValue: 'jdoe' },
-    loading: {
-      control: {
-        type: 'boolean',
-      },
-      defaultValue: false,
-    },
     inactive: {
       control: {
         type: 'boolean',
@@ -45,7 +39,6 @@ export const Default: Story = function Link(args) {
       </Form.Item>
       <UserAvatarWithDetailsPopover
         acronym={args.acronym}
-        loading={args.loading}
         onOpen={handleOnOpen}
         user={{
           acronym: args.acronym,

--- a/src/UserDetailsPopover/index.tsx
+++ b/src/UserDetailsPopover/index.tsx
@@ -28,8 +28,8 @@ export function UserDetailsPopover({
       destroyTooltipOnHide
       mouseEnterDelay={1}
       content={<UserDetailsPopoverContent onOpen={onOpen} user={user} />}
-      // hide popover while user is loading
-      visible={!user ? false : undefined}
+      // hide popover while user is loading to avoid janky UI
+      visible={user ? undefined : false}
     >
       {children}
     </Popover>

--- a/src/UserDetailsPopover/index.tsx
+++ b/src/UserDetailsPopover/index.tsx
@@ -28,6 +28,8 @@ export function UserDetailsPopover({
       destroyTooltipOnHide
       mouseEnterDelay={1}
       content={<UserDetailsPopoverContent onOpen={onOpen} user={user} />}
+      // hide popover while user is loading
+      visible={!user ? false : undefined}
     >
       {children}
     </Popover>

--- a/src/UserDetailsPopover/index.tsx
+++ b/src/UserDetailsPopover/index.tsx
@@ -3,7 +3,6 @@ import React, { PropsWithChildren, useEffect } from 'react';
 
 import { UserAvatar } from '../Avatar';
 import { Popover } from '../Popover';
-import { Spinner } from '../Spinner';
 
 import { UserDetails, UserDetailsProps } from './UserDetails';
 
@@ -15,14 +14,12 @@ export type UserDetailsPopoverProps = Modify<
   }
 > &
   PropsWithChildren<{
-    loading: boolean;
     /** Called once when popover opens to enable lazy loading of data. */
     onOpen?: () => void;
   }>;
 
 export function UserDetailsPopover({
   children,
-  loading,
   onOpen,
   user,
 }: UserDetailsPopoverProps) {
@@ -30,13 +27,7 @@ export function UserDetailsPopover({
     <Popover
       destroyTooltipOnHide
       mouseEnterDelay={1}
-      content={
-        <UserDetailsPopoverContent
-          loading={loading}
-          onOpen={onOpen}
-          user={user}
-        />
-      }
+      content={<UserDetailsPopoverContent onOpen={onOpen} user={user} />}
     >
       {children}
     </Popover>
@@ -56,7 +47,6 @@ export function UserAvatarWithDetailsPopover(
 }
 
 function UserDetailsPopoverContent({
-  loading,
   onOpen,
   user,
 }: Omit<UserDetailsPopoverProps, 'children'>) {
@@ -65,7 +55,8 @@ function UserDetailsPopoverContent({
     onOpen?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  return (
-    <Spinner spinning={loading}>{user && <UserDetails user={user} />}</Spinner>
-  );
+  if (!user) {
+    return null;
+  }
+  return <UserDetails user={user} />;
 }


### PR DESCRIPTION
When the popover opens while data is loading, the popover jumped after loading finished.

This fixes the behavior to show the popover content only when user data is loaded.