### PR TITLE
fix: call callback while popover content is invisible

### DIFF
--- a/src/UserDetailsPopover/RowWithLabel.tsx
+++ b/src/UserDetailsPopover/RowWithLabel.tsx
@@ -9,7 +9,7 @@ export function RowWithLabel({
   label,
 }: PropsWithChildren<{ label: ReactNode }>) {
   return (
-    <Row gutter={GUTTER} align="middle">
+    <Row gutter={GUTTER} align="middle" wrap={false}>
       <Col flex="20px">{label}</Col>
       <Col flex="auto">{children}</Col>
     </Row>

--- a/src/UserDetailsPopover/index.stories.tsx
+++ b/src/UserDetailsPopover/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Story } from '@storybook/react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { Form } from '../Form';
 import { Space } from '../Space';
@@ -30,8 +30,7 @@ export default {
 };
 
 export const Default: Story = function Link(args) {
-  const [calledOnOpen, setCalledOnOpen] = useState(false);
-  const handleOnOpen = useCallback(() => setCalledOnOpen(true), []);
+  const [visible, setVisible] = useState(false);
   return (
     <Space
       direction="vertical"
@@ -40,12 +39,14 @@ export const Default: Story = function Link(args) {
         marginLeft: 100,
       }}
     >
-      <Form.Item label="onOpen-Callback was called">
-        {calledOnOpen ? 'Yes' : 'No'}
+      <Form.Item label="onVisibleChange was called">
+        {visible ? 'Yes' : 'No'}
       </Form.Item>
       <UserAvatarWithDetailsPopover
         acronym={args.acronym}
-        onOpen={handleOnOpen}
+        popover={{
+          onVisibleChange: setVisible,
+        }}
         user={
           args.userUndefined
             ? undefined
@@ -64,6 +65,7 @@ export const Default: Story = function Link(args) {
 };
 
 export const WithCustomChildren: Story = function Link(args) {
+  const [visible, setVisible] = useState(false);
   const userProps = useMemo(
     () => ({
       acronym: args.acronym,
@@ -84,7 +86,15 @@ export const WithCustomChildren: Story = function Link(args) {
         marginLeft: 100,
       }}
     >
-      <UserDetailsPopover user={args.userUndefined ? undefined : userProps}>
+      <Form.Item label="onVisibleChange was called">
+        {visible ? 'Yes' : 'No'}
+      </Form.Item>
+      <UserDetailsPopover
+        popover={{
+          onVisibleChange: setVisible,
+        }}
+        user={args.userUndefined ? undefined : userProps}
+      >
         {args.username}
       </UserDetailsPopover>
     </Space>

--- a/src/UserDetailsPopover/index.tsx
+++ b/src/UserDetailsPopover/index.tsx
@@ -34,7 +34,7 @@ export function UserDetailsPopover({
       content={<UserDetailsPopoverContent user={user} />}
       overlayStyle={{
         // hide overlay while user is loading to avoid janky UI
-        display: !user ? 'none' : undefined,
+        display: user ? undefined : 'none',
         ...popover.overlayStyle,
       }}
     >

--- a/src/UserDetailsPopover/index.tsx
+++ b/src/UserDetailsPopover/index.tsx
@@ -1,8 +1,8 @@
 import { Modify } from '@mll-lab/js-utils';
-import React, { PropsWithChildren, useEffect } from 'react';
+import React, { PropsWithChildren } from 'react';
 
 import { UserAvatar } from '../Avatar';
-import { Popover } from '../Popover';
+import { Popover, PopoverProps } from '../Popover';
 
 import { UserDetails, UserDetailsProps } from './UserDetails';
 
@@ -14,22 +14,29 @@ export type UserDetailsPopoverProps = Modify<
   }
 > &
   PropsWithChildren<{
-    /** Called once when popover opens to enable lazy loading of data. */
-    onOpen?: () => void;
+    popover: Modify<
+      Omit<PopoverProps, 'content'>,
+      { onVisibleChange: PopoverProps['onVisibleChange'] }
+    >;
   }>;
 
 export function UserDetailsPopover({
   children,
-  onOpen,
+  popover,
   user,
 }: UserDetailsPopoverProps) {
   return (
     <Popover
+      mouseEnterDelay={0.8}
+      mouseLeaveDelay={0}
       destroyTooltipOnHide
-      mouseEnterDelay={1}
-      content={<UserDetailsPopoverContent onOpen={onOpen} user={user} />}
-      // hide popover while user is loading to avoid janky UI
-      visible={user ? undefined : false}
+      {...popover}
+      content={<UserDetailsPopoverContent user={user} />}
+      overlayStyle={{
+        // hide overlay while user is loading to avoid janky UI
+        display: !user ? 'none' : undefined,
+        ...popover.overlayStyle,
+      }}
     >
       {children}
     </Popover>
@@ -49,14 +56,8 @@ export function UserAvatarWithDetailsPopover(
 }
 
 function UserDetailsPopoverContent({
-  onOpen,
   user,
-}: Omit<UserDetailsPopoverProps, 'children'>) {
-  useEffect(() => {
-    // call once when popover opens to enable lazy loading of data
-    onOpen?.();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+}: Pick<UserDetailsPopoverProps, 'user'>) {
   if (!user) {
     return null;
   }


### PR DESCRIPTION
- fix that callback was never called when content was passed as undefined or null by using `display: none` instead to hide the popover
- accept all tooltip props for further customizatione like mouseEnterDelay
- keep email in one row