### PR TITLE
fix: facilitate moving mouse into popover 

### DIFF
--- a/src/UserDetailsPopover/index.tsx
+++ b/src/UserDetailsPopover/index.tsx
@@ -27,9 +27,9 @@ export function UserDetailsPopover({
 }: UserDetailsPopoverProps) {
   return (
     <Popover
-      mouseEnterDelay={0.8}
-      mouseLeaveDelay={0}
       destroyTooltipOnHide
+      mouseEnterDelay={0.8}
+      mouseLeaveDelay={0.1}
       {...popover}
       content={<UserDetailsPopoverContent user={user} />}
       overlayStyle={{

--- a/src/UserDetailsPopover/index.tsx
+++ b/src/UserDetailsPopover/index.tsx
@@ -29,7 +29,6 @@ export function UserDetailsPopover({
     <Popover
       destroyTooltipOnHide
       mouseEnterDelay={0.8}
-      mouseLeaveDelay={0.1}
       {...popover}
       content={<UserDetailsPopoverContent user={user} />}
       overlayStyle={{


### PR DESCRIPTION
With the current `mouseLeaveDelay={0}` the user can't move the mouse into the popover before the popover closes. 0.1 is the default mouseLeaveDelay, which works well.