### PR TITLE
fix: allow styling input components

### DIFF
--- a/src/Fields/InputField.tsx
+++ b/src/Fields/InputField.tsx
@@ -5,19 +5,19 @@ import {
   UseControllerProps,
   FieldPath,
 } from 'react-hook-form';
+import styled from 'styled-components';
 
 import { Input, InputProps } from '../Input';
 
 import { useFieldContext } from './FieldProvider';
 import { FieldWrapper, FieldWrapperProps } from './FieldWrapper';
-import styled from 'styled-components';
 
 type StyledInputProps = Omit<InputProps, 'style'> & {
   // TODO handle console warning:
   // React does not recognize the `inputStyle` prop on a DOM element.
   inputStyle: InputProps['style'];
   wrapperStyle: InputProps['style'];
-}
+};
 
 type InputFieldProps<
   TFieldValues extends FieldValues,

--- a/src/Fields/InputField.tsx
+++ b/src/Fields/InputField.tsx
@@ -10,13 +10,21 @@ import { Input, InputProps } from '../Input';
 
 import { useFieldContext } from './FieldProvider';
 import { FieldWrapper, FieldWrapperProps } from './FieldWrapper';
+import styled from 'styled-components';
+
+type StyledInputProps = Omit<InputProps, 'style'> & {
+  // TODO handle console warning:
+  // React does not recognize the `inputStyle` prop on a DOM element.
+  inputStyle: InputProps['style'];
+  wrapperStyle: InputProps['style'];
+}
 
 type InputFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
 > = UseControllerProps<TFieldValues, TName> &
   Pick<FieldWrapperProps<TFieldValues, TName>, 'formItem'> & {
-    component?: InputProps;
+    component?: StyledInputProps;
   };
 
 export function InputField<
@@ -33,11 +41,12 @@ export function InputField<
 
   return (
     <FieldWrapper controller={controller} formItem={formItem}>
-      <Input
+      <StyledInput
         {...field}
         value={field.value ?? undefined}
         disabled={disabled}
         {...component}
+        style={component?.wrapperStyle}
         // Avoid losing focus when triggering/resolving a validation error
         // https://4x.ant.design/components/input/#Why-Input-lose-focus-when-change-prefix/suffix/showCount
         suffix={component?.suffix || <span />}
@@ -45,3 +54,9 @@ export function InputField<
     </FieldWrapper>
   );
 }
+
+const StyledInput = styled(Input)`
+  .mll-ant-input {
+    ${(props) => props.inputStyle}
+  }
+`;

--- a/src/Fields/InputField.tsx
+++ b/src/Fields/InputField.tsx
@@ -5,26 +5,18 @@ import {
   UseControllerProps,
   FieldPath,
 } from 'react-hook-form';
-import styled from 'styled-components';
 
 import { Input, InputProps } from '../Input';
 
 import { useFieldContext } from './FieldProvider';
 import { FieldWrapper, FieldWrapperProps } from './FieldWrapper';
 
-type StyledInputProps = Omit<InputProps, 'style'> & {
-  // TODO handle console warning:
-  // React does not recognize the `inputStyle` prop on a DOM element.
-  inputStyle: InputProps['style'];
-  wrapperStyle: InputProps['style'];
-};
-
 type InputFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
 > = UseControllerProps<TFieldValues, TName> &
   Pick<FieldWrapperProps<TFieldValues, TName>, 'formItem'> & {
-    component?: StyledInputProps;
+    component?: InputProps;
   };
 
 export function InputField<
@@ -41,12 +33,11 @@ export function InputField<
 
   return (
     <FieldWrapper controller={controller} formItem={formItem}>
-      <StyledInput
+      <Input
         {...field}
         value={field.value ?? undefined}
         disabled={disabled}
         {...component}
-        style={component?.wrapperStyle}
         // Avoid losing focus when triggering/resolving a validation error
         // https://4x.ant.design/components/input/#Why-Input-lose-focus-when-change-prefix/suffix/showCount
         suffix={component?.suffix || <span />}
@@ -54,9 +45,3 @@ export function InputField<
     </FieldWrapper>
   );
 }
-
-const StyledInput = styled(Input)`
-  .mll-ant-input {
-    ${(props) => props.inputStyle}
-  }
-`;

--- a/src/Fields/TextAreaField.tsx
+++ b/src/Fields/TextAreaField.tsx
@@ -5,17 +5,17 @@ import {
   UseControllerProps,
   FieldPath,
 } from 'react-hook-form';
+import styled from 'styled-components';
 
 import { Input, TextAreaProps, TextAreaRef } from '../Input';
 
 import { useFieldContext } from './FieldProvider';
 import { FieldWrapper, FieldWrapperProps } from './FieldWrapper';
-import styled from 'styled-components';
 
 type StyledTextAreaProps = Omit<TextAreaProps, 'style'> & {
   inputStyle: TextAreaProps['style'];
   wrapperStyle: TextAreaProps['style'];
-}
+};
 
 type TextAreaFieldProps<
   TFieldValues extends FieldValues,

--- a/src/Fields/TextAreaField.tsx
+++ b/src/Fields/TextAreaField.tsx
@@ -5,24 +5,18 @@ import {
   UseControllerProps,
   FieldPath,
 } from 'react-hook-form';
-import styled from 'styled-components';
 
-import { Input, TextAreaProps, TextAreaRef } from '../Input';
+import { TextArea, TextAreaProps, TextAreaRef } from '../Input';
 
 import { useFieldContext } from './FieldProvider';
 import { FieldWrapper, FieldWrapperProps } from './FieldWrapper';
-
-type StyledTextAreaProps = Omit<TextAreaProps, 'style'> & {
-  inputStyle: TextAreaProps['style'];
-  wrapperStyle: TextAreaProps['style'];
-};
 
 type TextAreaFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
 > = UseControllerProps<TFieldValues, TName> &
   Pick<FieldWrapperProps<TFieldValues, TName>, 'formItem'> & {
-    component?: StyledTextAreaProps & {
+    component?: TextAreaProps & {
       ref?: React.Ref<TextAreaRef>;
     };
   };
@@ -41,7 +35,7 @@ export function TextAreaField<
 
   return (
     <FieldWrapper controller={controller} formItem={formItem}>
-      <StyledTextArea
+      <TextArea
         {...field}
         value={field.value ?? undefined}
         disabled={disabled}
@@ -53,9 +47,3 @@ export function TextAreaField<
     </FieldWrapper>
   );
 }
-
-const StyledTextArea = styled(Input.TextArea)`
-  .mll-ant-input {
-    ${(props) => props.inputStyle}
-  }
-`;

--- a/src/Fields/TextAreaField.tsx
+++ b/src/Fields/TextAreaField.tsx
@@ -10,13 +10,19 @@ import { Input, TextAreaProps, TextAreaRef } from '../Input';
 
 import { useFieldContext } from './FieldProvider';
 import { FieldWrapper, FieldWrapperProps } from './FieldWrapper';
+import styled from 'styled-components';
+
+type StyledTextAreaProps = Omit<TextAreaProps, 'style'> & {
+  inputStyle: TextAreaProps['style'];
+  wrapperStyle: TextAreaProps['style'];
+}
 
 type TextAreaFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
 > = UseControllerProps<TFieldValues, TName> &
   Pick<FieldWrapperProps<TFieldValues, TName>, 'formItem'> & {
-    component?: TextAreaProps & {
+    component?: StyledTextAreaProps & {
       ref?: React.Ref<TextAreaRef>;
     };
   };
@@ -35,7 +41,7 @@ export function TextAreaField<
 
   return (
     <FieldWrapper controller={controller} formItem={formItem}>
-      <Input.TextArea
+      <StyledTextArea
         {...field}
         value={field.value ?? undefined}
         disabled={disabled}
@@ -47,3 +53,9 @@ export function TextAreaField<
     </FieldWrapper>
   );
 }
+
+const StyledTextArea = styled(Input.TextArea)`
+  .mll-ant-input {
+    ${(props) => props.inputStyle}
+  }
+`;

--- a/src/Fields/index.stories.tsx
+++ b/src/Fields/index.stories.tsx
@@ -138,14 +138,14 @@ function AllFields() {
         rules={{ required: 'You really need this', maxLength: 3 }}
         control={formMethods.control}
         formItem={{
-          label: 'Input Required',
+          label: 'Input required',
         }}
       />
       <InputField
         name="input"
         control={formMethods.control}
         formItem={{
-          label: 'Input Bold',
+          label: 'Input styled',
         }}
         component={{
           $inputStyle: { fontWeight: 'bold' },
@@ -158,14 +158,14 @@ function AllFields() {
         rules={{ required: 'Absolutely necessary' }}
         control={formMethods.control}
         formItem={{
-          label: 'InputNumber Required',
+          label: 'InputNumber required',
         }}
       />
       <RadioGroupField
         name="radio_group"
         control={formMethods.control}
         formItem={{
-          label: 'Radio Group',
+          label: 'RadioGroup',
         }}
         component={{
           options: [1, 2],
@@ -195,18 +195,18 @@ function AllFields() {
 
 function TextAreaStory() {
   const { control } = useFormContext<FormType>();
-  const textArea1Ref = useRef<TextAreaRef>(null);
-  const textAreaRedRef = useRef<TextAreaRef>(null);
+  const textAreaRequiredRef = useRef<TextAreaRef>(null);
+  const textAreaStyledRef = useRef<TextAreaRef>(null);
   return (
     <Space direction="horizontal">
       <TextAreaField
         name="text_area"
         control={control}
         formItem={{
-          label: 'TextArea 1',
+          label: 'TextArea required',
         }}
         component={{
-          ref: textArea1Ref,
+          ref: textAreaRequiredRef,
           minLength: 3,
         }}
         rules={{ required: 'Very necessary' }}
@@ -215,10 +215,10 @@ function TextAreaStory() {
         name="text_area"
         control={control}
         formItem={{
-          label: 'TextArea red',
+          label: 'TextArea styled',
         }}
         component={{
-          ref: textAreaRedRef,
+          ref: textAreaStyledRef,
           minLength: 3,
           $inputStyle: {
             borderColor: 'red',
@@ -226,11 +226,11 @@ function TextAreaStory() {
           },
         }}
       />
-      <Button onClick={() => textArea1Ref.current?.focus()}>
-        Focus TextArea 1
+      <Button onClick={() => textAreaRequiredRef.current?.focus()}>
+        Focus TextArea required
       </Button>
-      <Button onClick={() => textAreaRedRef.current?.focus()}>
-        Focus TextArea red
+      <Button onClick={() => textAreaStyledRef.current?.focus()}>
+        Focus TextArea styled
       </Button>
     </Space>
   );

--- a/src/Fields/index.stories.tsx
+++ b/src/Fields/index.stories.tsx
@@ -150,7 +150,7 @@ function AllFields() {
         component={{
           style: { fontWeight: 'bold' },
         }}
-        defaultValue={'some bold text'}
+        defaultValue="some bold text"
       />
       <InputNumberField
         name="input_number"

--- a/src/Fields/index.stories.tsx
+++ b/src/Fields/index.stories.tsx
@@ -148,7 +148,7 @@ function AllFields() {
           label: 'Input Bold',
         }}
         component={{
-          style: { fontWeight: 'bold' },
+          inputStyle: { fontWeight: 'bold' },
         }}
         defaultValue="some bold text"
       />
@@ -219,7 +219,7 @@ function TextAreaStory() {
         component={{
           ref: textAreaRedRef,
           minLength: 3,
-          style: {
+          inputStyle: {
             borderColor: 'red',
             backgroundColor: 'pink',
           },

--- a/src/Fields/index.stories.tsx
+++ b/src/Fields/index.stories.tsx
@@ -188,14 +188,37 @@ function AllFields() {
           label: 'Switch',
         }}
       />
-      <TextAreaWithRef />
+      <TextAreaStory />
+    </Form>
+  );
+}
+
+function TextAreaStory() {
+  const { control } = useFormContext<FormType>();
+  const textArea1Ref = useRef<TextAreaRef>(null);
+  const textAreaRedRef = useRef<TextAreaRef>(null);
+  return (
+    <Space direction="horizontal">
       <TextAreaField
         name="text_area"
-        control={formMethods.control}
+        control={control}
+        formItem={{
+          label: 'TextArea 1',
+        }}
+        component={{
+          ref: textArea1Ref,
+          minLength: 3,
+        }}
+        rules={{ required: 'Very necessary' }}
+      />
+      <TextAreaField
+        name="text_area"
+        control={control}
         formItem={{
           label: 'TextArea red',
         }}
         component={{
+          ref: textAreaRedRef,
           minLength: 3,
           $inputStyle: {
             borderColor: 'red',
@@ -203,29 +226,11 @@ function AllFields() {
           },
         }}
       />
-    </Form>
-  );
-}
-
-function TextAreaWithRef() {
-  const { control } = useFormContext<FormType>();
-  const textAreaRef = useRef<TextAreaRef>(null);
-  return (
-    <Space>
-      <TextAreaField
-        name="text_area"
-        control={control}
-        formItem={{
-          label: 'TextArea',
-        }}
-        component={{
-          ref: textAreaRef,
-          minLength: 3,
-        }}
-        rules={{ required: 'Very necessary' }}
-      />
-      <Button onClick={() => textAreaRef.current?.focus()}>
-        Focus TextArea
+      <Button onClick={() => textArea1Ref.current?.focus()}>
+        Focus TextArea 1
+      </Button>
+      <Button onClick={() => textAreaRedRef.current?.focus()}>
+        Focus TextArea red
       </Button>
     </Space>
   );

--- a/src/Fields/index.stories.tsx
+++ b/src/Fields/index.stories.tsx
@@ -141,6 +141,17 @@ function AllFields() {
           label: 'Input Label',
         }}
       />
+      <InputField
+        name="input"
+        control={formMethods.control}
+        formItem={{
+          label: 'Input Bold',
+        }}
+        component={{
+          style: { fontWeight: 'bold' },
+        }}
+        defaultValue={'some bold text'}
+      />
       <InputNumberField
         name="input_number"
         rules={{ required: 'Absolutely necessary' }}
@@ -184,7 +195,7 @@ function AllFields() {
 function TextAreaStory() {
   const { control } = useFormContext<FormType>();
   const textArea1Ref = useRef<TextAreaRef>(null);
-  const textArea2Ref = useRef<TextAreaRef>(null);
+  const textAreaRedRef = useRef<TextAreaRef>(null);
   return (
     <Space direction="horizontal">
       <TextAreaField
@@ -203,18 +214,22 @@ function TextAreaStory() {
         name="text_area"
         control={control}
         formItem={{
-          label: 'TextArea 2',
+          label: 'TextArea red',
         }}
         component={{
-          ref: textArea2Ref,
+          ref: textAreaRedRef,
           minLength: 3,
+          style: {
+            borderColor: 'red',
+            backgroundColor: 'pink',
+          },
         }}
       />
       <Button onClick={() => textArea1Ref.current?.focus()}>
         Focus TextArea 1
       </Button>
-      <Button onClick={() => textArea2Ref.current?.focus()}>
-        Focus TextArea 2
+      <Button onClick={() => textAreaRedRef.current?.focus()}>
+        Focus TextArea red
       </Button>
     </Space>
   );

--- a/src/Fields/index.stories.tsx
+++ b/src/Fields/index.stories.tsx
@@ -128,7 +128,7 @@ function AllFields() {
         name="checkbox"
         control={formMethods.control}
         formItem={{
-          label: 'Checkbox Label',
+          label: 'Checkbox',
         }}
       >
         Checkbox children
@@ -138,7 +138,7 @@ function AllFields() {
         rules={{ required: 'You really need this', maxLength: 3 }}
         control={formMethods.control}
         formItem={{
-          label: 'Input Label',
+          label: 'Input Required',
         }}
       />
       <InputField
@@ -148,7 +148,8 @@ function AllFields() {
           label: 'Input Bold',
         }}
         component={{
-          inputStyle: { fontWeight: 'bold' },
+          $inputStyle: { fontWeight: 'bold' },
+          $wrapperStyle: { border: '5px red solid' },
         }}
         defaultValue="some bold text"
       />
@@ -157,14 +158,14 @@ function AllFields() {
         rules={{ required: 'Absolutely necessary' }}
         control={formMethods.control}
         formItem={{
-          label: 'InputNumber Label',
+          label: 'InputNumber Required',
         }}
       />
       <RadioGroupField
         name="radio_group"
         control={formMethods.control}
         formItem={{
-          label: 'InputNumber Label',
+          label: 'Radio Group',
         }}
         component={{
           options: [1, 2],
@@ -174,7 +175,7 @@ function AllFields() {
         name="select"
         control={formMethods.control}
         formItem={{
-          label: 'Select Label',
+          label: 'Select',
         }}
         component={{
           options: ['a', 'b'].map(toFormInputOption),
@@ -184,52 +185,47 @@ function AllFields() {
         name="switch"
         control={formMethods.control}
         formItem={{
-          label: 'Switch Label',
+          label: 'Switch',
         }}
       />
-      <TextAreaStory />
-    </Form>
-  );
-}
-
-function TextAreaStory() {
-  const { control } = useFormContext<FormType>();
-  const textArea1Ref = useRef<TextAreaRef>(null);
-  const textAreaRedRef = useRef<TextAreaRef>(null);
-  return (
-    <Space direction="horizontal">
+      <TextAreaWithRef />
       <TextAreaField
         name="text_area"
-        control={control}
-        formItem={{
-          label: 'TextArea 1',
-        }}
-        component={{
-          ref: textArea1Ref,
-          minLength: 3,
-        }}
-        rules={{ required: 'Very necessary' }}
-      />
-      <TextAreaField
-        name="text_area"
-        control={control}
+        control={formMethods.control}
         formItem={{
           label: 'TextArea red',
         }}
         component={{
-          ref: textAreaRedRef,
           minLength: 3,
-          inputStyle: {
+          $inputStyle: {
             borderColor: 'red',
             backgroundColor: 'pink',
           },
         }}
       />
-      <Button onClick={() => textArea1Ref.current?.focus()}>
-        Focus TextArea 1
-      </Button>
-      <Button onClick={() => textAreaRedRef.current?.focus()}>
-        Focus TextArea red
+    </Form>
+  );
+}
+
+function TextAreaWithRef() {
+  const { control } = useFormContext<FormType>();
+  const textAreaRef = useRef<TextAreaRef>(null);
+  return (
+    <Space>
+      <TextAreaField
+        name="text_area"
+        control={control}
+        formItem={{
+          label: 'TextArea',
+        }}
+        component={{
+          ref: textAreaRef,
+          minLength: 3,
+        }}
+        rules={{ required: 'Very necessary' }}
+      />
+      <Button onClick={() => textAreaRef.current?.focus()}>
+        Focus TextArea
       </Button>
     </Space>
   );

--- a/src/Input/common.ts
+++ b/src/Input/common.ts
@@ -8,27 +8,59 @@ import {
 import { TextAreaProps as AntdTextAreaProps } from 'antd/es/input';
 import { SearchProps as AntdSearchProps } from 'antd/es/input/Search';
 import { TextAreaRef as AntdTextAreaRef } from 'antd/es/input/TextArea';
-import styled from 'styled-components';
+import styled, { CSSObject } from 'styled-components';
 
 import { fontSizeFromTheme } from '../styled-utils';
 
-export const Input: typeof AntdInput = styled(AntdInput)`
-  font-size: ${fontSizeFromTheme};
+export const Input = styled(AntdInput).attrs((props: InputProps) => ({
+  style: props.$wrapperStyle,
+}))<InputProps>`
+  /* The DOM structure changes when prefix/suffix/validation are used. */
+  .mll-ant-input,
+  &.mll-ant-input {
+    font-size: ${fontSizeFromTheme};
+    ${(props) => props.$inputStyle}
+  }
 `;
-export type InputProps = AntdInputProps;
+export type InputProps = Omit<AntdInputProps, 'style'> & {
+  $inputStyle?: CSSObject | undefined;
+  $wrapperStyle?: AntdInputProps['style'];
+};
 export type InputRef = AntdInputRef;
 
-export const InputNumber: typeof AntdInputNumber = styled(AntdInputNumber)`
-  font-size: ${fontSizeFromTheme};
+export const InputNumber = styled(AntdInputNumber).attrs(
+  (props: InputNumberProps) => ({
+    style: props.$wrapperStyle,
+  }),
+)<InputNumberProps>`
+  /* The DOM structure changes when prefix/suffix/validation are used. */
+  .mll-ant-input,
+  &.mll-ant-input {
+    font-size: ${fontSizeFromTheme};
+    ${(props) => props.$inputStyle}
+  }
 `;
-export type InputNumberProps = AntdInputNumberProps;
+export type InputNumberProps = Omit<AntdInputNumberProps, 'style'> & {
+  $inputStyle?: CSSObject | undefined;
+  $wrapperStyle?: AntdInputProps['style'];
+};
 
 const AntdTextArea = Input.TextArea;
-export const TextArea: typeof AntdTextArea = styled(AntdTextArea)`
-  font-size: ${fontSizeFromTheme};
+export const TextArea = styled(AntdTextArea).attrs((props: TextAreaProps) => ({
+  style: props.$wrapperStyle,
+}))<TextAreaProps>`
+  /* The DOM structure changes when prefix/suffix/validation are used. */
+  .mll-ant-input,
+  &.mll-ant-input {
+    font-size: ${fontSizeFromTheme};
+    ${(props) => props.$inputStyle}
+  }
 `;
 Input.TextArea = TextArea;
-export type TextAreaProps = AntdTextAreaProps;
+export type TextAreaProps = Omit<AntdTextAreaProps, 'style'> & {
+  $inputStyle?: CSSObject | undefined;
+  $wrapperStyle?: AntdTextAreaProps['style'];
+};
 export type TextAreaRef = AntdTextAreaRef;
 
 const AntdSearch = Input.Search;

--- a/src/Input/common.ts
+++ b/src/Input/common.ts
@@ -8,11 +8,17 @@ import {
 import { TextAreaProps as AntdTextAreaProps } from 'antd/es/input';
 import { SearchProps as AntdSearchProps } from 'antd/es/input/Search';
 import { TextAreaRef as AntdTextAreaRef } from 'antd/es/input/TextArea';
+import { ForwardRefExoticComponent, RefAttributes } from 'react';
 import styled, { CSSObject } from 'styled-components';
 
 import { fontSizeFromTheme } from '../styled-utils';
 
-export const Input = styled(AntdInput).attrs((props: InputProps) => ({
+export const Input: ForwardRefExoticComponent<
+  InputProps & RefAttributes<InputRef>
+> & {
+  Search: typeof Search;
+  TextArea: typeof TextArea;
+} = styled(AntdInput).attrs((props: InputProps) => ({
   style: props.$wrapperStyle,
 }))<InputProps>`
   /* The DOM structure changes when prefix/suffix/validation are used. */
@@ -45,10 +51,13 @@ export type InputNumberProps = Omit<AntdInputNumberProps, 'style'> & {
   $wrapperStyle?: AntdInputProps['style'];
 };
 
-const AntdTextArea = Input.TextArea;
-export const TextArea = styled(AntdTextArea).attrs((props: TextAreaProps) => ({
-  style: props.$wrapperStyle,
-}))<TextAreaProps>`
+const AntdTextArea = AntdInput.TextArea;
+export const TextArea: ForwardRefExoticComponent<TextAreaProps> &
+  RefAttributes<TextAreaRef> = styled(AntdTextArea).attrs(
+  (props: TextAreaProps) => ({
+    style: props.$wrapperStyle,
+  }),
+)<TextAreaProps>`
   /* The DOM structure changes when prefix/suffix/validation are used. */
   .mll-ant-input,
   &.mll-ant-input {
@@ -63,7 +72,7 @@ export type TextAreaProps = Omit<AntdTextAreaProps, 'style'> & {
 };
 export type TextAreaRef = AntdTextAreaRef;
 
-const AntdSearch = Input.Search;
+const AntdSearch = AntdInput.Search;
 const Search: typeof AntdSearch = styled(AntdSearch)`
   /* Present in the original styles, see https://4x.ant.design/components/input/#components-input-demo-search-input */
   /* Probably gets lost due to wrong handling of the mll-ant prefix? */

--- a/src/Input/index.stories.tsx
+++ b/src/Input/index.stories.tsx
@@ -32,7 +32,16 @@ export const Text: Story<InputProps> = function Text(args) {
 };
 
 export const TextArea: Story<TextAreaProps> = function TextArea(args) {
-  return <Input.TextArea {...args} />;
+  return (
+    <Space>
+      <Input.TextArea {...args} />
+      <Input.TextArea
+        $inputStyle={{ background: 'red' }}
+        $wrapperStyle={{ border: '5px green solid' }}
+        {...args}
+      />
+    </Space>
+  );
 };
 
 export const Search: Story<SearchProps> = function Search(args) {

--- a/src/Input/index.stories.tsx
+++ b/src/Input/index.stories.tsx
@@ -1,6 +1,8 @@
 import { Story } from '@storybook/react';
 import React, { useState } from 'react';
 
+import { Space } from '../Space';
+
 import { NumericIDInput, NumericIDInputProps } from './NumericIDInput';
 import {
   InputNumberProps,
@@ -17,7 +19,16 @@ export default {
 };
 
 export const Text: Story<InputProps> = function Text(args) {
-  return <Input {...args} />;
+  return (
+    <Space>
+      <Input {...args} />
+      <Input
+        $inputStyle={{ background: 'red' }}
+        $wrapperStyle={{ border: '5px green solid' }}
+        {...args}
+      />
+    </Space>
+  );
 };
 
 export const TextArea: Story<TextAreaProps> = function TextArea(args) {


### PR DESCRIPTION
Resolves https://github.com/mll-lab/react-components/issues/231

Always having a wrapper element present (https://github.com/mll-lab/react-components/pull/218) causes the property `style` to
become attached to the wrapper element, not the actual `input` or `textarea` (https://github.com/ant-design/ant-design/issues/9941).
Due to CSS inheritance rules and special treatment of input elements, some properties such as `background-color` or any `font-*`
can not be set then, they need to be directly on the input element.

BREAKING CHANGE: replace prop `style` in `Input`, `TextArea` and `InputNumber` with `$wrapperStyle`