### PR TITLE
feat: add missing DnD-Context-Props to Plate via `draggable`-property

### DIFF
--- a/src/Plate/FilledWell.tsx
+++ b/src/Plate/FilledWell.tsx
@@ -19,7 +19,6 @@ export function FilledWell(props: {
       row: rowForPosition(props.position, PLATE_FLOW),
       column: columnForPosition(props.position, PLATE_FLOW),
     },
-    well: props.well,
   };
 
   const { attributes, listeners, setNodeRef, transform } = useDraggable({

--- a/src/Plate/index.stories.tsx
+++ b/src/Plate/index.stories.tsx
@@ -64,9 +64,11 @@ const DraggablePlateTemplate: Story<Partial<PlateProps>> =
       <Plate
         data={null}
         {...args}
-        onDragEnd={
-          action('onDragEnd') // dataLocation: `const sourceData = e.active.data.current; const targetData = e.over?.data.current;`
-        }
+        draggable={{
+          dndContextProps: {
+            onDragEnd: action('onDragEnd'), // dataLocation: `const sourceData = e.active.data.current; const targetData = e.over?.data.current;`
+          },
+        }}
       />
     );
   };

--- a/src/Plate/index.stories.tsx
+++ b/src/Plate/index.stories.tsx
@@ -64,10 +64,8 @@ const DraggablePlateTemplate: Story<Partial<PlateProps>> =
       <Plate
         data={null}
         {...args}
-        draggable={{
-          dndContextProps: {
-            onDragEnd: action('onDragEnd'), // dataLocation: `const sourceData = e.active.data.current; const targetData = e.over?.data.current;`
-          },
+        dndContextProps={{
+          onDragEnd: action('onDragEnd'), // dataLocation: `const sourceData = e.active.data.current; const targetData = e.over?.data.current;`
         }}
       />
     );

--- a/src/Plate/index.tsx
+++ b/src/Plate/index.tsx
@@ -24,7 +24,7 @@ export function Plate(props: PlateProps) {
   }
 
   return (
-    <DndContext {...props.draggable?.dndContextProps}>
+    <DndContext {...props.dndContextProps}>
       <Spin
         spinning={props.loading ?? false}
         indicator={
@@ -72,7 +72,7 @@ export function Plate(props: PlateProps) {
                     ? wellAtPosition(position, props.data, PLATE_FLOW)
                     : undefined
                 }
-                isDraggable={Boolean(props.draggable)}
+                isDraggable={Boolean(props.dndContextProps)}
               />
             </Fragment>
           ))}

--- a/src/Plate/index.tsx
+++ b/src/Plate/index.tsx
@@ -1,4 +1,4 @@
-import { DndContext, rectIntersection } from '@dnd-kit/core';
+import { DndContext } from '@dnd-kit/core';
 import { Spin } from 'antd';
 import React, { Fragment } from 'react';
 
@@ -24,10 +24,7 @@ export function Plate(props: PlateProps) {
   }
 
   return (
-    <DndContext
-      collisionDetection={rectIntersection}
-      onDragEnd={(e) => props.onDragEnd?.(e)}
-    >
+    <DndContext {...props.draggable?.dndContextProps}>
       <Spin
         spinning={props.loading ?? false}
         indicator={
@@ -75,7 +72,7 @@ export function Plate(props: PlateProps) {
                     ? wellAtPosition(position, props.data, PLATE_FLOW)
                     : undefined
                 }
-                isDraggable={Boolean(props.onDragEnd)}
+                isDraggable={Boolean(props.draggable)}
               />
             </Fragment>
           ))}

--- a/src/Plate/types.ts
+++ b/src/Plate/types.ts
@@ -1,4 +1,4 @@
-import { DragEndEvent } from '@dnd-kit/core/dist/types';
+import { Props } from '@dnd-kit/core/dist/components/DndContext/DndContext';
 import { ReactNode } from 'react';
 
 export type Coordinates = {
@@ -17,5 +17,9 @@ export type PlateWell = {
 export type PlateProps = {
   data: Array<PlateWell> | null;
   loading?: boolean;
-  onDragEnd?: (event: DragEndEvent) => void;
+  draggable?: DraggableProps;
+};
+
+export type DraggableProps = {
+  dndContextProps?: Props;
 };

--- a/src/Plate/types.ts
+++ b/src/Plate/types.ts
@@ -17,9 +17,5 @@ export type PlateWell = {
 export type PlateProps = {
   data: Array<PlateWell> | null;
   loading?: boolean;
-  draggable?: DraggableProps;
-};
-
-export type DraggableProps = {
   dndContextProps?: Props;
 };


### PR DESCRIPTION
BREAKING: replace `onDragEnd`-property with more detailed `draggable`-property
BREAKING: delete well-data from FilledWell