### PR TITLE
fix: use coordinates instead of coordinate on data of draggable well

### DIFF
--- a/src/Plate/EmptyWell.tsx
+++ b/src/Plate/EmptyWell.tsx
@@ -11,7 +11,7 @@ export function EmptyWell(props: { position: number }) {
   const { setNodeRef, isOver } = useDroppable({
     id: props.position,
     data: {
-      coordinate: {
+      coordinates: {
         row: rowForPosition(props.position, PLATE_FLOW),
         column: columnForPosition(props.position, PLATE_FLOW),
       },

--- a/src/Plate/FilledWell.tsx
+++ b/src/Plate/FilledWell.tsx
@@ -15,7 +15,7 @@ export function FilledWell(props: {
   isDraggable: boolean;
 }) {
   const data = {
-    coordinate: {
+    coordinates: {
       row: rowForPosition(props.position, PLATE_FLOW),
       column: columnForPosition(props.position, PLATE_FLOW),
     },


### PR DESCRIPTION
BRAKING CHANGE: use coordinates instead of coordinate on data of draggable well