### PR TITLE
feat: customizable collapse transition

### DIFF
--- a/src/Collapse/Collapse.ts
+++ b/src/Collapse/Collapse.ts
@@ -1,7 +1,7 @@
 import { Collapse as AntdCollapse } from 'antd';
 import { CollapseProps as AntdCollapseProps } from 'antd/lib/collapse/Collapse';
 import { CollapsePanelProps as AntdCollapsePanelProps } from 'antd/lib/collapse/CollapsePanel';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { fontSizeFromTheme } from '../styled-utils';
 
@@ -17,6 +17,14 @@ const StyledCollapse: typeof AntdCollapse = styled(
   }
   .mll-ant-collapse-item > .mll-ant-collapse-header {
     align-items: center;
+  }
+
+  .ant-motion-collapse {
+    ${(props) =>
+      props.theme.collapseTransition &&
+      css`
+        transition: ${props.theme.collapseTransition} !important;
+      `}
   }
 `;
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -36,6 +36,7 @@ export type Theme = {
   backgroundColor: string;
   borderColor: string;
   collapseBackgroundColor: string;
+  collapseTransition?: string;
   containerBorderColor: string;
   dividerColor: string;
   focusedRowColor: string;
@@ -66,6 +67,7 @@ export const THEME: Theme = {
   backgroundColor: PALETTE.blueTintedGray,
   borderColor: PALETTE.blue,
   collapseBackgroundColor: PALETTE.lightBlue,
+  collapseTransition: '0.05s',
   containerBorderColor: PALETTE.gray4,
   dividerColor: PALETTE.gray4,
   focusedRowColor: PALETTE.lightBlue,


### PR DESCRIPTION
Make Collapse transition configurable through Provider.

Default of AntD is 0.3ms, which is too long for time-sensitive operations.