### PR TITLE
fix: skip ref for DatePicker

### DIFF
--- a/src/Fields/DatePickerField.tsx
+++ b/src/Fields/DatePickerField.tsx
@@ -27,13 +27,13 @@ export function DatePickerField<
   component,
   ...controller
 }: DatePickerFieldProps<TFieldValues, TName>) {
-  const { field } = useController<TFieldValues, TName>(controller);
+  const { field: { ref, ...fieldProps } } = useController<TFieldValues, TName>(controller);
 
   const { disabled } = useFieldContext();
 
   return (
     <FieldWrapper controller={controller} formItem={formItem}>
-      <DatePicker disabled={disabled} {...field} {...component} />
+      <DatePicker disabled={disabled} {...fieldProps} {...component} />
     </FieldWrapper>
   );
 }

--- a/src/Fields/DatePickerField.tsx
+++ b/src/Fields/DatePickerField.tsx
@@ -27,7 +27,9 @@ export function DatePickerField<
   component,
   ...controller
 }: DatePickerFieldProps<TFieldValues, TName>) {
-  const { field: { ref, ...fieldProps } } = useController<TFieldValues, TName>(controller);
+  const {
+    field: { ref, ...fieldProps },
+  } = useController<TFieldValues, TName>(controller);
 
   const { disabled } = useFieldContext();
 


### PR DESCRIPTION
Currently, there is the warning in console because of a ref being passed:

![grafik](https://github.com/mll-lab/react-components/assets/4448508/15631217-1ff8-4c52-900f-990877108ea0)
