### PR TITLE
fix: reset stripes for expanded rows

### DIFF
--- a/src/Table/index.stories.tsx
+++ b/src/Table/index.stories.tsx
@@ -137,3 +137,26 @@ export function ColoredTable() {
     />
   );
 }
+
+export function NestedColoredTable() {
+  const [selectedID, setSelectedID] = useState<number>();
+
+  return (
+    <StyledTable<Person>
+      bordered
+      columns={columns}
+      dataSource={data}
+      pagination={false}
+      onRow={(person) => ({
+        onClick: () => setSelectedID(person.id),
+      })}
+      rowSelection={{
+        selectedRowKeys: selectedID ? [selectedID] : undefined,
+        hideSelectAll: true,
+        renderCell: () => null,
+        columnWidth: 0,
+      }}
+      expandable={{ expandedRowRender: () => <ColoredTable /> }}
+    />
+  );
+}

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -129,8 +129,16 @@ export const ColoredTable = styled(Table)`
   /* Stripe rows */
 
   /* Depending on the table layout, the header may or may not count as a row */
-  .mll-ant-table.mll-ant-table-fixed-header tr:nth-child(odd) td,
-  .mll-ant-table:not(.mll-ant-table-fixed-header) tr:nth-child(even) td {
+  .mll-ant-table.mll-ant-table-fixed-header
+    tr:not(.mll-ant-table-expanded-row):nth-child(
+      odd of tr:not(.mll-ant-table-expanded-row)
+    )
+    > td,
+  .mll-ant-table:not(.mll-ant-table-fixed-header)
+    tr:not(.mll-ant-table-expanded-row):nth-child(
+      even of tr:not(.mll-ant-table-expanded-row)
+    )
+    > td {
     background-color: ${(props) => props.theme.tableRowStripeBackgroundColor};
   }
 


### PR DESCRIPTION
With nested table, alternating rows background getting messed up because of an additional tr-element being dynamically added to the table.

Before:

![image](https://github.com/user-attachments/assets/c0945a7b-5f5d-494f-ab3c-cf1418baf891)


After:

![image](https://github.com/user-attachments/assets/a7bbc2ea-e280-4cab-a707-dc410ab4876b)