### PR TITLE
feat: use tableHeaderFontColor from theme

### DIFF
--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -97,7 +97,7 @@ export const ColoredTable = styled(Table)`
   /* Show the header in deep blue */
   th.mll-ant-table-cell {
     background-color: ${(props) => props.theme.tableHeaderBackgroundColor};
-    color: white;
+    color: ${(props) => props.theme.tableHeaderFontColor};
   }
 
   /* Less jarring than the default hover color */

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -55,6 +55,7 @@ export type Theme = {
   warningColor: string;
 
   tableHeaderBackgroundColor: string;
+  tableHeaderFontColor: string;
   tableRowStripeBackgroundColor: string;
 
   fontSize?: string;
@@ -75,6 +76,7 @@ export const THEME: Theme = {
   panelBackgroundColor: PALETTE.gray3,
   tableBorderColor: PALETTE.gray4,
   tableHeaderBackgroundColor: PALETTE.tableHeaderBackgroundColor,
+  tableHeaderFontColor: PALETTE.white,
   tableRowStripeBackgroundColor: PALETTE.tableRowStripeBackgroundColor,
   titleColor: PALETTE.gray5,
   disabledColors: {


### PR DESCRIPTION
Currently, only `background-color` uses the attribute `tableHeaderBackgroundColor` from theme. 