### PR TITLE
fix: use disabled context after field props

### DIFF
--- a/src/Fields/DatePickerField.tsx
+++ b/src/Fields/DatePickerField.tsx
@@ -35,7 +35,7 @@ export function DatePickerField<
 
   return (
     <FieldWrapper controller={controller} formItem={formItem}>
-      <DatePicker disabled={disabled} {...fieldProps} {...component} />
+      <DatePicker {...fieldProps} disabled={disabled} {...component} />
     </FieldWrapper>
   );
 }

--- a/src/Fields/DateRangePickerField.tsx
+++ b/src/Fields/DateRangePickerField.tsx
@@ -8,6 +8,7 @@ import {
   UseControllerProps,
 } from 'react-hook-form';
 
+import { useFieldContext } from './FieldProvider';
 import { FieldWrapper, FieldWrapperProps } from './FieldWrapper';
 import { PICKER_LOCALE } from './pickerLocale';
 
@@ -30,12 +31,15 @@ export function DateRangePickerField<
   ...controller
 }: DateRangePickerFieldProps<TFieldValues, TName>) {
   const { field } = useController<TFieldValues, TName>(controller);
+  const { disabled } = useFieldContext();
+
   return (
     <FieldWrapper controller={controller} formItem={formItem}>
       <RangePicker
         format={['DD.MM.YYYY', 'DDMMYYYY']}
         locale={PICKER_LOCALE}
         {...field}
+        disabled={disabled}
         {...component}
       />
     </FieldWrapper>


### PR DESCRIPTION
Otherwise it will be overwritten by `field.disabled`.